### PR TITLE
Pin tower crates to tenx-tech forks with specific revisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,17 +31,26 @@ futures = "0.1"
 http = "0.1"
 h2 = "0.1"
 log = "0.4"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-service = { git = "https://github.com/tower-rs/tower" }
 
 # For protobuf
 prost = { version = "0.4", optional = true }
 
+[dependencies.tower-h2]
+git = "https://github.com/tenx-tech/tower-h2"
+rev = "12c3c55"
+
+[dependencies.tower-service]
+git = "https://github.com/tower-rs/tower"
+rev = "20fb04e"
+
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
-tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-core = "0.1"
 
 # For examples
 prost = "0.4"
 prost-derive = "0.4"
+
+[dev-dependencies.tokio-connect]
+git = "https://github.com/carllerche/tokio-connect"
+rev = "f7ad1ca"

--- a/tests/multifile/Cargo.toml
+++ b/tests/multifile/Cargo.toml
@@ -8,8 +8,11 @@ publish = false
 bytes = "0.4"
 prost = "0.4"
 prost-derive = "0.4"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
+
+[dependencies.tower-h2]
+git = "https://github.com/tenx-tech/tower-h2"
+rev = "12c3c55"
 
 [build-dependencies]
 tower-grpc-build = { path = "../../tower-grpc-build" }

--- a/tests/name-case/Cargo.toml
+++ b/tests/name-case/Cargo.toml
@@ -8,9 +8,11 @@ publish = false
 bytes = "0.4"
 prost = "0.4"
 prost-derive = "0.4"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
+
+[dependencies.tower-h2]
+git = "https://github.com/tenx-tech/tower-h2"
+rev = "12c3c55"
 
 [build-dependencies]
 tower-grpc-build = { path = "../../tower-grpc-build" }
-

--- a/tests/unused-imports/Cargo.toml
+++ b/tests/unused-imports/Cargo.toml
@@ -8,8 +8,11 @@ publish = false
 bytes = "0.4"
 prost = "0.4"
 prost-derive = "0.4"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
 tower-grpc = { path = "../../" }
+
+[dependencies.tower-h2]
+git = "https://github.com/tenx-tech/tower-h2"
+rev = "12c3c55"
 
 [build-dependencies]
 tower-grpc-build = { path = "../../tower-grpc-build" }

--- a/tower-grpc-build/Cargo.toml
+++ b/tower-grpc-build/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 
 [dependencies]
-codegen = { git = "https://github.com/carllerche/codegen" }
 prost-build = "0.4"
 heck = "0.3"
+
+[dependencies.codegen]
+git = "https://github.com/carllerche/codegen"
+rev = "9b2f818"

--- a/tower-grpc-examples/Cargo.toml
+++ b/tower-grpc-examples/Cargo.toml
@@ -28,15 +28,24 @@ http = "0.1"
 prost = "0.4"
 prost-derive = "0.4"
 tokio-core = "0.1"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
-tower-service = { git = "https://github.com/tower-rs/tower" }
 
 # For the routeguide example
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+
+[dependencies.tower-h2]
+git = "https://github.com/tenx-tech/tower-h2"
+rev = "12c3c55"
+
+[dependencies.tower-http]
+git = "https://github.com/tenx-tech/tower-http"
+rev = "19e769b"
+
+[dependencies.tower-service]
+git = "https://github.com/tower-rs/tower"
+rev = "20fb04e"
 
 [build-dependencies]
 tower-grpc-build = { path = "../tower-grpc-build" }

--- a/tower-grpc-interop/Cargo.toml
+++ b/tower-grpc-interop/Cargo.toml
@@ -17,15 +17,24 @@ http = "0.1"
 prost = "0.4"
 prost-derive = "0.4"
 tokio-core = "0.1"
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2" }
-tower-http = { git = "https://github.com/tower-rs/tower-http" }
 tower-grpc = { path = "../" }
-tower-service = { git = "https://github.com/tower-rs/tower" }
 
 clap = "~2.29"
 console = "0.5.0"
 rustls = "0.11.0"
 domain = "0.2.2"
+
+[dependencies.tower-h2]
+git = "https://github.com/tenx-tech/tower-h2"
+rev = "12c3c55"
+
+[dependencies.tower-http]
+git = "https://github.com/tenx-tech/tower-http"
+rev = "19e769b"
+
+[dependencies.tower-service]
+git = "https://github.com/tower-rs/tower"
+rev = "20fb04e"
 
 [build-dependencies]
 tower-grpc-build = { path = "../tower-grpc-build" }


### PR DESCRIPTION
### Changed

* Update `Cargo.toml` for `tower-grpc`.
* Update `Cargo.toml` for `tower-grpc-examples`.
* Update `Cargo.toml` for `tower-grpc-interop`.
* Update `Cargo.toml` for test crates `multifile`, `name-case`, and `unused-imports`.